### PR TITLE
Cordova 3.x require-based JavaScript handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,6 @@ $ cordova plugin add https://github.com/EddyVerbruggen/SSLCertificateChecker-Pho
 ```
 Run `cordova prepare` or `cordova build` afterwards.
 
-Add this reference to your `index.html`:
-```html
-<script type="text/javascript" src="js/plugins/SSLCertificateChecker.js"></script>
-```
-
 ### Manually
 
 1\. Add the following xml to your `config.xml`:
@@ -89,12 +84,6 @@ Using SSLCertificateChecker with PhoneGap Build requires these simple steps:
 or to use this exact version:
 ```xml
 <gap:plugin name="nl.x-services.plugins.sslcertificatechecker" version="3.0" />
-```
-
-2\. Reference the JavaScript code in your `index.html`:
-```html
-<!-- below <script src="phonegap.js"></script> -->
-<script src="js/plugins/SSLCertificateChecker.js"></script>
 ```
 
 ## 3. Usage

--- a/plugin.xml
+++ b/plugin.xml
@@ -18,7 +18,9 @@
     <engine name="cordova" version=">=3.0.0"/>
   </engines>
 
-  <asset src="www/SSLCertificateChecker.js" target="js/plugins/SSLCertificateChecker.js"/>
+  <js-module name="SSLCertificateChecker" src="www/SSLCertificateChecker.js">
+    <clobbers target="window.plugins.sslCertificateChecker" />
+  </js-module>
 
   <!-- ios -->
  	<platform name="ios">

--- a/www/SSLCertificateChecker.js
+++ b/www/SSLCertificateChecker.js
@@ -1,4 +1,6 @@
 "use strict";
+var exec = require('cordova/exec');
+
 function SSLCertificateChecker() {
 }
 
@@ -15,13 +17,5 @@ SSLCertificateChecker.prototype.check = function (successCallback, errorCallback
   cordova.exec(successCallback, errorCallback, "SSLCertificateChecker", "check", [serverURL, allowedSHA1Fingerprint, allowedSHA1FingerprintAlt]);
 };
 
-SSLCertificateChecker.install = function () {
-  if (!window.plugins) {
-    window.plugins = {};
-  }
-
-  window.plugins.sslCertificateChecker = new SSLCertificateChecker();
-  return window.plugins.sslCertificateChecker;
-};
-
-cordova.addConstructor(SSLCertificateChecker.install);
+var sslCertificateChecker = new SSLCertificateChecker();
+module.exports = sslCertificateChecker;


### PR DESCRIPTION
Modified to use `js-module` and `clobbers` in `plugin.xml` instead of manually adding a script tag to `index.html`
