### PR TITLE
Now throws error when connection unsafe.

### DIFF
--- a/src/android/nl/xservices/plugins/SSLCertificateChecker.java
+++ b/src/android/nl/xservices/plugins/SSLCertificateChecker.java
@@ -33,7 +33,7 @@ public class SSLCertificateChecker extends CordovaPlugin {
             if (allowedFingerprint.equalsIgnoreCase(serverCertFingerprint) || allowedFingerprintAlt.equalsIgnoreCase(serverCertFingerprint)) {
               callbackContext.success("CONNECTION_SECURE");
             } else {
-              callbackContext.success("CONNECTION_NOT_SECURE");
+              callbackContext.error("CONNECTION_NOT_SECURE");
             }
           } catch (Exception e) {
             callbackContext.error("CONNECTION_FAILED. Details: " + e.getMessage());


### PR DESCRIPTION
I noticed when testing that when the fingerprints don't match, success is called with the "CONNECTION_NOT_SECURE" error message. 

If using the code sample in your README.MD, it will cause an insecure certificate to be trusted.
