### PR TITLE
Close connection as soon as server identity is retrieved

### DIFF
--- a/src/ios/SSLCertificateChecker.m
+++ b/src/ios/SSLCertificateChecker.m
@@ -31,6 +31,8 @@
 - (void) connection: (NSURLConnection*)connection willSendRequestForAuthenticationChallenge: (NSURLAuthenticationChallenge*)challenge {
     NSString* fingerprint = [self getFingerprint: SecTrustGetCertificateAtIndex(challenge.protectionSpace.serverTrust, 0)];
 
+    [connection cancel];
+
     self.sentResponse = TRUE;
     if ([self isFingerprintTrusted: fingerprint]) {
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"CONNECTION_SECURE"];


### PR DESCRIPTION
This is also avoiding a problem with iOS8 (issue #15) where only the first call to the plugin will go through. Thanks to closing the connection, the plugin can be called multiple times.

I validated it with simple tests on an iPhone and emulator running iOS 8.0.2, but a validation from an experienced Obj C developer would be required as my knowledge of it is limited.
