### PR TITLE
Allow check for fingerprint anywhere in the certificate signing chain

### DIFF
--- a/src/android/nl/xservices/plugins/SSLCertificateChecker.java
+++ b/src/android/nl/xservices/plugins/SSLCertificateChecker.java
@@ -26,14 +26,22 @@ public class SSLCertificateChecker extends CordovaPlugin {
         public void run() {
           try {
             final String serverURL = args.getString(0);
-            final String allowedFingerprint = args.getString(1);
-            final String allowedFingerprintAlt = args.getString(2);
-            final String serverCertFingerprint = getFingerprint(serverURL);
-
-            if (allowedFingerprint.equalsIgnoreCase(serverCertFingerprint) || allowedFingerprintAlt.equalsIgnoreCase(serverCertFingerprint)) {
-              callbackContext.success("CONNECTION_SECURE");
-            } else {
-              callbackContext.error("CONNECTION_NOT_SECURE");
+            final Boolean checkInCertChain = args.getBoolean(1);
+            final String allowedFingerprint = args.getString(2);
+            final String allowedFingerprintAlt = args.getString(3);
+            String[] serverCertFingerprints = getFingerprints(serverURL);
+            
+            Boolean certFound = false;
+            int certChainCheckDepth = checkInCertChain ? serverCertFingerprints.length : 1;
+            for (int i=0; i<certChainCheckDepth; i++) {
+	            if (allowedFingerprint.equalsIgnoreCase(serverCertFingerprints[i]) || allowedFingerprintAlt.equalsIgnoreCase(serverCertFingerprints[i])) {
+	            	certFound = true;
+	            	callbackContext.success("CONNECTION_SECURE");
+	            	break;
+	            }
+            }
+            if (! certFound) {
+            	callbackContext.error("CONNECTION_NOT_SECURE");
             }
           } catch (Exception e) {
             callbackContext.error("CONNECTION_FAILED. Details: " + e.getMessage());
@@ -47,13 +55,17 @@ public class SSLCertificateChecker extends CordovaPlugin {
     }
   }
 
-  private static String getFingerprint(String httpsURL) throws IOException, NoSuchAlgorithmException, CertificateException, CertificateEncodingException {
+  private static String[] getFingerprints(String httpsURL) throws IOException, NoSuchAlgorithmException, CertificateException, CertificateEncodingException {
     final HttpsURLConnection con = (HttpsURLConnection) new URL(httpsURL).openConnection();
     con.connect();
-    final Certificate cert = con.getServerCertificates()[0];
+    final Certificate[] certs = con.getServerCertificates();
+    final String[] fingerprints = new String[certs.length];
     final MessageDigest md = MessageDigest.getInstance("SHA1");
-    md.update(cert.getEncoded());
-    return dumpHex(md.digest());
+    for (int i=0; i<certs.length; i++) {
+        md.update(certs[i].getEncoded());
+        fingerprints[i]=dumpHex(md.digest());
+    }
+    return fingerprints;
   }
 
   private static String dumpHex(byte[] data) {

--- a/src/ios/SSLCertificateChecker.m
+++ b/src/ios/SSLCertificateChecker.m
@@ -7,44 +7,86 @@
 
 @property (strong, nonatomic) CDVPlugin *_plugin;
 @property (strong, nonatomic) NSString *_callbackId;
+@property (nonatomic, assign) BOOL _checkInCertChain;
 @property (strong, nonatomic) NSString *_allowedFingerprint;
 @property (strong, nonatomic) NSString *_allowedFingerprintAlt;
 @property (nonatomic, assign) BOOL sentResponse;
 
-- (id)initWithPlugin:(CDVPlugin*)plugin callbackId:(NSString*)callbackId allowedFingerprint:(NSString*)allowedFingerprint allowedFingerprintAlt:(NSString*)allowedFingerprintAlt;
+- (id)initWithPlugin:(CDVPlugin*)plugin callbackId:(NSString*)callbackId checkInCertChain:(BOOL)checkInCertChain allowedFingerprint:(NSString*)allowedFingerprint allowedFingerprintAlt:(NSString*)allowedFingerprintAlt;
 
 @end
 
 @implementation CustomURLConnectionDelegate
 
-- (id)initWithPlugin:(CDVPlugin*)plugin callbackId:(NSString*)callbackId allowedFingerprint:(NSString*)allowedFingerprint allowedFingerprintAlt:(NSString*)allowedFingerprintAlt
+- (id)initWithPlugin:(CDVPlugin*)plugin callbackId:(NSString*)callbackId checkInCertChain:(BOOL)checkInCertChain allowedFingerprint:(NSString*)allowedFingerprint allowedFingerprintAlt:(NSString*)allowedFingerprintAlt
 {
-	self.sentResponse = FALSE;
-	self._plugin = plugin;
-	self._callbackId = callbackId;
-	self._allowedFingerprint = allowedFingerprint;
-	self._allowedFingerprintAlt = allowedFingerprintAlt;
+    NSLog(@"initWithPlugin");
+    self.sentResponse = FALSE;
+    self._plugin = plugin;
+    self._callbackId = callbackId;
+    self._checkInCertChain = checkInCertChain;
+    self._allowedFingerprint = allowedFingerprint;
+    self._allowedFingerprintAlt = allowedFingerprintAlt;
     return self;
 }
 
 // Delegate method, called from connectionWithRequest
 - (void) connection: (NSURLConnection*)connection willSendRequestForAuthenticationChallenge: (NSURLAuthenticationChallenge*)challenge {
-    NSString* fingerprint = [self getFingerprint: SecTrustGetCertificateAtIndex(challenge.protectionSpace.serverTrust, 0)];
-
+    NSLog(@"willSendRequestForAuthenticationChallenge");
+    SecTrustRef trustRef = [[challenge protectionSpace] serverTrust];
+    SecTrustEvaluate(trustRef, NULL);
+    
+    //    [challenge.sender continueWithoutCredentialForAuthenticationChallenge:challenge];
     [connection cancel];
-
-    self.sentResponse = TRUE;
-    if ([self isFingerprintTrusted: fingerprint]) {
-        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"CONNECTION_SECURE"];
-        [self._plugin writeJavascript:[pluginResult toSuccessCallbackString:self._callbackId]];
-    } else {
+    
+    CFIndex count = 1;
+    if (self._checkInCertChain) {
+        count = SecTrustGetCertificateCount(trustRef);
+    }
+    
+    for (CFIndex i = 0; i < count; i++)
+    {
+        SecCertificateRef certRef = SecTrustGetCertificateAtIndex(trustRef, i);
+        CFStringRef certSummary = SecCertificateCopySubjectSummary(certRef);
+        
+        NSString* fingerprint = [self getFingerprint:certRef];
+        
+        NSLog(@"Certificate #%ld in chain: %@", i, certSummary);
+        NSLog(@"  fingerprint:%@", fingerprint);
+        
+        if ([self isFingerprintTrusted: fingerprint]) {
+            CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"CONNECTION_SECURE"];
+            [self._plugin writeJavascript:[pluginResult toSuccessCallbackString:self._callbackId]];
+            self.sentResponse = TRUE;
+            break;
+        }
+    }
+    
+    if (! self.sentResponse) {
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_JSON_EXCEPTION messageAsString:@"CONNECTION_NOT_SECURE"];
         [self._plugin writeJavascript:[pluginResult toErrorCallbackString:self._callbackId]];
     }
+    
+    /*
+     NSString* fingerprint = [self getFingerprint: SecTrustGetCertificateAtIndex(challenge.protectionSpace.serverTrust, 0)];
+     
+     self.sentResponse = TRUE;
+     if ([self isFingerprintTrusted: fingerprint]) {
+     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"CONNECTION_SECURE"];
+     [self._plugin writeJavascript:[pluginResult toSuccessCallbackString:self._callbackId]];
+     } else {
+     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_JSON_EXCEPTION messageAsString:@"CONNECTION_NOT_SECURE"];
+     [self._plugin writeJavascript:[pluginResult toErrorCallbackString:self._callbackId]];
+     }
+     */
 }
 
 // Delegate method, called from connectionWithRequest
 - (void) connection: (NSURLConnection*)connection didFailWithError: (NSError*)error {
+    NSLog(@"didFailWithError");
+    
+    connection = nil;
+    
     NSString *resultCode = @"CONNECTION_FAILED. Details:";
     NSString *errStr = [NSString stringWithFormat:@"%@ %@", resultCode, [error localizedDescription]];
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_JSON_EXCEPTION messageAsString:errStr];
@@ -53,6 +95,10 @@
 
 - (void)connectionDidFinishLoading:(NSURLConnection *)connection
 {
+    NSLog(@"connectionDidFinishLoading");
+    
+    connection = nil;
+    
     if (![self sentResponse]) {
         NSLog(@"Connection was not checked because it was cached. Considering it secure to not break your app.");
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"CONNECTION_SECURE"];
@@ -89,16 +135,19 @@
 @implementation SSLCertificateChecker
 
 - (void)check:(CDVInvokedUrlCommand*)command {
+    NSLog(@"command");
     NSString *serverURL = [command.arguments objectAtIndex:0];
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:serverURL]];
-                             
-                             CustomURLConnectionDelegate *delegate =
-                             [[CustomURLConnectionDelegate alloc] initWithPlugin:self callbackId:command.callbackId allowedFingerprint:[command.arguments objectAtIndex:1] allowedFingerprintAlt:[command.arguments objectAtIndex:2]];
-                             
-                             if (![NSURLConnection connectionWithRequest:request delegate:delegate]) {
-                                 CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_JSON_EXCEPTION messageAsString:@"CONNECTION_FAILED"];
-                                 [self writeJavascript:[pluginResult toErrorCallbackString:command.callbackId]];
-                             }
-                             }
-                             
-                             @end
+    
+    CustomURLConnectionDelegate *delegate =
+    [[CustomURLConnectionDelegate alloc] initWithPlugin:self callbackId:command.callbackId checkInCertChain:[[command.arguments objectAtIndex:1] boolValue] allowedFingerprint:[command.arguments objectAtIndex:2] allowedFingerprintAlt:[command.arguments objectAtIndex:3]];
+    
+    if (![NSURLConnection connectionWithRequest:request delegate:delegate]) {
+        
+        NSLog(@"NSURLConnection failed");
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_JSON_EXCEPTION messageAsString:@"CONNECTION_FAILED"];
+        [self writeJavascript:[pluginResult toErrorCallbackString:command.callbackId]];
+    }
+}
+
+@end

--- a/src/ios/SSLCertificateChecker.m
+++ b/src/ios/SSLCertificateChecker.m
@@ -20,7 +20,6 @@
 
 - (id)initWithPlugin:(CDVPlugin*)plugin callbackId:(NSString*)callbackId checkInCertChain:(BOOL)checkInCertChain allowedFingerprint:(NSString*)allowedFingerprint allowedFingerprintAlt:(NSString*)allowedFingerprintAlt
 {
-    NSLog(@"initWithPlugin");
     self.sentResponse = FALSE;
     self._plugin = plugin;
     self._callbackId = callbackId;
@@ -32,7 +31,6 @@
 
 // Delegate method, called from connectionWithRequest
 - (void) connection: (NSURLConnection*)connection willSendRequestForAuthenticationChallenge: (NSURLAuthenticationChallenge*)challenge {
-    NSLog(@"willSendRequestForAuthenticationChallenge");
     SecTrustRef trustRef = [[challenge protectionSpace] serverTrust];
     SecTrustEvaluate(trustRef, NULL);
     
@@ -51,9 +49,6 @@
         
         NSString* fingerprint = [self getFingerprint:certRef];
         
-        NSLog(@"Certificate #%ld in chain: %@", i, certSummary);
-        NSLog(@"  fingerprint:%@", fingerprint);
-        
         if ([self isFingerprintTrusted: fingerprint]) {
             CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"CONNECTION_SECURE"];
             [self._plugin writeJavascript:[pluginResult toSuccessCallbackString:self._callbackId]];
@@ -67,24 +62,10 @@
         [self._plugin writeJavascript:[pluginResult toErrorCallbackString:self._callbackId]];
     }
     
-    /*
-     NSString* fingerprint = [self getFingerprint: SecTrustGetCertificateAtIndex(challenge.protectionSpace.serverTrust, 0)];
-     
-     self.sentResponse = TRUE;
-     if ([self isFingerprintTrusted: fingerprint]) {
-     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"CONNECTION_SECURE"];
-     [self._plugin writeJavascript:[pluginResult toSuccessCallbackString:self._callbackId]];
-     } else {
-     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_JSON_EXCEPTION messageAsString:@"CONNECTION_NOT_SECURE"];
-     [self._plugin writeJavascript:[pluginResult toErrorCallbackString:self._callbackId]];
-     }
-     */
 }
 
 // Delegate method, called from connectionWithRequest
 - (void) connection: (NSURLConnection*)connection didFailWithError: (NSError*)error {
-    NSLog(@"didFailWithError");
-    
     connection = nil;
     
     NSString *resultCode = @"CONNECTION_FAILED. Details:";
@@ -95,8 +76,6 @@
 
 - (void)connectionDidFinishLoading:(NSURLConnection *)connection
 {
-    NSLog(@"connectionDidFinishLoading");
-    
     connection = nil;
     
     if (![self sentResponse]) {
@@ -135,7 +114,6 @@
 @implementation SSLCertificateChecker
 
 - (void)check:(CDVInvokedUrlCommand*)command {
-    NSLog(@"command");
     NSString *serverURL = [command.arguments objectAtIndex:0];
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:serverURL]];
     
@@ -143,9 +121,7 @@
     [[CustomURLConnectionDelegate alloc] initWithPlugin:self callbackId:command.callbackId checkInCertChain:[[command.arguments objectAtIndex:1] boolValue] allowedFingerprint:[command.arguments objectAtIndex:2] allowedFingerprintAlt:[command.arguments objectAtIndex:3]];
     
     if (![NSURLConnection connectionWithRequest:request delegate:delegate]) {
-        
-        NSLog(@"NSURLConnection failed");
-        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_JSON_EXCEPTION messageAsString:@"CONNECTION_FAILED"];
+ns        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_JSON_EXCEPTION messageAsString:@"CONNECTION_FAILED"];
         [self writeJavascript:[pluginResult toErrorCallbackString:command.callbackId]];
     }
 }

--- a/www/SSLCertificateChecker.js
+++ b/www/SSLCertificateChecker.js
@@ -14,8 +14,21 @@ SSLCertificateChecker.prototype.check = function (successCallback, errorCallback
     console.log("SSLCertificateChecker.find failure: successCallback parameter must be a function");
     return
   }
-  cordova.exec(successCallback, errorCallback, "SSLCertificateChecker", "check", [serverURL, allowedSHA1Fingerprint, allowedSHA1FingerprintAlt]);
+  cordova.exec(successCallback, errorCallback, "SSLCertificateChecker", "check", [serverURL, false, allowedSHA1Fingerprint, allowedSHA1FingerprintAlt]);
 };
+
+SSLCertificateChecker.prototype.checkInCertChain = function (successCallback, errorCallback, serverURL, allowedSHA1Fingerprint, allowedSHA1FingerprintAlt) {
+  if (typeof errorCallback != "function") {
+    console.log("SSLCertificateChecker.find failure: errorCallback parameter must be a function");
+    return
+  }
+  if (typeof successCallback != "function") {
+    console.log("SSLCertificateChecker.find failure: successCallback parameter must be a function");
+    return
+  }
+  cordova.exec(successCallback, errorCallback, "SSLCertificateChecker", "check", [serverURL, true, allowedSHA1Fingerprint, allowedSHA1FingerprintAlt]);
+};
+
 
 var sslCertificateChecker = new SSLCertificateChecker();
 module.exports = sslCertificateChecker;


### PR DESCRIPTION
I added a new API "checkInCertChain" allowing fingerprints to be checked against the server certificate or any certificate in the signing chain.
This allow pinning to a Certificate Authority certificate what can be good enough from a security viewpoint and would avoid changing fingerprints in case of server certificate renewal is if same CA is used.