### PR TITLE
Set timeout on Android to 5 seconds

### DIFF
--- a/src/android/nl/xservices/plugins/SSLCertificateChecker.java
+++ b/src/android/nl/xservices/plugins/SSLCertificateChecker.java
@@ -49,6 +49,7 @@ public class SSLCertificateChecker extends CordovaPlugin {
 
   private static String getFingerprint(String httpsURL) throws IOException, NoSuchAlgorithmException, CertificateException, CertificateEncodingException {
     final HttpsURLConnection con = (HttpsURLConnection) new URL(httpsURL).openConnection();
+    con.setConnectTimeout(5000);
     con.connect();
     final Certificate cert = con.getServerCertificates()[0];
     final MessageDigest md = MessageDigest.getInstance("SHA1");


### PR DESCRIPTION
Set timeout to 5 seconds.
Sometimes onresume the ssl pinning is not working on Android and might fire only after 5 minutes.

This 5 seconds timeout reduces the overall loading time to 15 seconds.
